### PR TITLE
Update facility.py

### DIFF
--- a/src/rules/facility.py
+++ b/src/rules/facility.py
@@ -18,10 +18,6 @@ guid_constant = Constant('Facility Guid', 'GUID', 'Guid()')
 
 fips_calculation = Calculation('County Fips', 'CountyFIPS', load_rule_for(FOLDER, 'fipsCalculation'))
 
-id_calculation = Calculation('Facility Id', 'FacilityID', load_rule_for(FOLDER, 'idCalculation'))
-id_calculation.triggers = [config.triggers.insert, config.triggers.update]
-id_calculation.editable = config.editable.no
-
 city_calculation = Calculation('Facility City', 'FacilityCity', load_rule_for(FOLDER, 'cityCalculation'))
 
 zip_calculation = Calculation('Facility Zip', 'FacilityZIP', load_rule_for(FOLDER, 'zipCalculation'))
@@ -41,7 +37,6 @@ address_constraint_update.triggers = [config.triggers.update]
 RULES = [
     guid_constant,
     fips_calculation,
-    id_calculation,
     city_calculation,
     zip_calculation,
     fips_domain_constraint,


### PR DESCRIPTION
Remove attribute rule for FacilityID creation to prevent issues with data transfer from the UIC web application (https://github.com/uic-utah/uic-inventory) to the UIC Geodatabase. Future FacilityID creation will be handled by the UIC web application.